### PR TITLE
Crypto coingecko

### DIFF
--- a/modules/crypto/index.js
+++ b/modules/crypto/index.js
@@ -1,6 +1,8 @@
 const request = require('request');
 const util = require('util');
 
+const COIN_GECKO_URL = 'https://www.coingecko.com/en';
+
 module.exports = class Crypto extends (
   BaseModule
 ) {
@@ -25,7 +27,10 @@ module.exports = class Crypto extends (
       ];
       this.postFancyMessage(data, fields, '#4CAF50');
     } catch (e) {
-      this.bot.postMessage(data.channel, `${data.user_text} not found. :(`);
+      this.bot.postMessage(
+        data.channel,
+        `${data.user_text} not found. See coins: ${COIN_GECKO_URL}`
+      );
     }
   }
 
@@ -50,7 +55,7 @@ module.exports = class Crypto extends (
         {
           color: color,
           fields: fields,
-          footer: 'More symbols: https://www.coingecko.com/en',
+          footer: `More symbols: ${COIN_GECKO_URL}`,
         },
       ],
     });
@@ -97,6 +102,6 @@ module.exports = class Crypto extends (
   }
 
   help() {
-    return 'Get duh latest crypto info. `?crypto <symbol name>`. List of symbols: https://www.coingecko.com/en';
+    return `Get duh latest crypto info. \`?crypto <symbol name>\`. List of symbols: ${COIN_GECKO_URL}`;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-cat",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Crypto Gecko API
https://www.coingecko.com/en/api#explore-api

- Updates the default `?crypto` command to get the top 3 coins from crypto gecko. 
- Unfortunately crypto gecko doesn't have an EASY way to get crypto by ticker so I am leaving the `?crypto <coin>` command alone.

<img width="567" alt="Screen Shot 2020-12-08 at 11 43 09 AM" src="https://user-images.githubusercontent.com/3826772/101516466-8285bd80-394d-11eb-997d-ffb2533bf90c.png">
<img width="549" alt="Screen Shot 2020-12-08 at 11 45 48 AM" src="https://user-images.githubusercontent.com/3826772/101516467-8285bd80-394d-11eb-95cb-482c46706492.png">
