### PR TITLE
[HACKATHON] Add logic for capturing plus events for period aggregations (Project W.I.N)

### DIFF
--- a/modules/plus/index.js
+++ b/modules/plus/index.js
@@ -71,6 +71,7 @@ module.exports = class Plus extends BaseStorageModule {
       const pluses = await this.plusHelper.plusUser(
         data.user_text.toLowerCase()
       );
+      await this.plusHelper.plusEvent(data.user_text.toLowerCase());
       this.bot.postMessageToThread(
         data.channel,
         `${data.user_text} now has ${pluses} pluses!`,
@@ -98,6 +99,7 @@ module.exports = class Plus extends BaseStorageModule {
         }
         const userName = await this.getUserNameFromId(group[1]);
         const total = await this.plusHelper.plusUser(group[1]);
+        await this.plusHelper.plusEvent(group[1]);
         if (!plusMap[userName]) {
           plusMap[userName] = {
             occurrences: 0
@@ -151,8 +153,7 @@ module.exports = class Plus extends BaseStorageModule {
   }
 
   getReactionKey(data) {
-    return `${data.item_user}${data.item.ts}${data.user}${data.item.channel}${
-      data.item.reaction
+    return `${data.item_user}${data.item.ts}${data.user}${data.item.channel}${data.item.reaction
       }`;
   }
 
@@ -175,6 +176,16 @@ module.exports = class Plus extends BaseStorageModule {
     this.PlusModelNew = this.db.define('pluses_table', {
       slackid: { type: this.Sequelize.STRING, primaryKey: true },
       pluses: this.Sequelize.INTEGER,
+    }, { timestamps: false });
+
+    this.PlusEventModel = this.db.define('plus_events', {
+      slackid: this.Sequelize.STRING,
+      pluses: this.Sequelize.INTEGER,
+      creationTimestamp: {
+        type: this.Sequelize.DATE,
+        allowNull: false,
+        defaultValue: this.Sequelize.NOW
+      }
     }, { timestamps: false });
   }
 

--- a/modules/plus/plus-helper.js
+++ b/modules/plus/plus-helper.js
@@ -49,8 +49,7 @@ module.exports = class PlusHelper {
     const userData = await this.context.bot.getUserNameFromId(data.user);
     this.context.bot.postMessageToThread(
       data.channel,
-      `Don't be a meanie ${
-      userData.user.display_name
+      `Don't be a meanie ${userData.user.display_name
         ? userData.user.display_name
         : userData.user.name
       }`,
@@ -81,6 +80,15 @@ module.exports = class PlusHelper {
 
 
     return await pluses.get('pluses');
+  }
+
+  async plusEvent(userSlackId) {
+    await this.getPlusEventModel().create(
+      {
+        slackid: userSlackId,
+        pluses: 1
+      }
+    );
   }
 
 
@@ -121,7 +129,9 @@ module.exports = class PlusHelper {
   getPlusModel() {
     return database.modelManager.getModel("pluses_table")
   }
+
+  getPlusEventModel() {
+    return database.modelManager.getModel("plus_events")
+  }
+
 };
-
-
-

--- a/modules/plus/reaction-handler.js
+++ b/modules/plus/reaction-handler.js
@@ -16,6 +16,7 @@ module.exports.handlePlus = async (data, userName, plusHelper) => {
   }
 
   const pluses = await plusHelper.plusUser(data.item_user);
+  await plusHelper.plusEvent(data.item_user);
   cache.put(getReactionKey(data), '', 5 * 60 * 1000, () => { });
 
   return `${user} now has ${pluses} pluses!`;


### PR DESCRIPTION
I've added updated the `plus` module to include logic for capturing plus events to a new db table `plus_events`, so that we can calculate period aggregations for the Project W.I.N newsletter.

Since this is mainly just a POC, I'm submitting this as a draft PR for now. We'd likely want to add logic that truncates the `plus_events` table on a weekly basis.