### PR TITLE
Post "couldn't find team" error message to thread instead of channel

### DIFF
--- a/modules/pagerduty/index.js
+++ b/modules/pagerduty/index.js
@@ -39,9 +39,10 @@ module.exports = class PagerDuty extends BaseModule {
       const teamNames = teams.map(
         (obj) => `• ${obj.team_name} <#${obj.channel_id}>`
       );
-      this.bot.postMessage(
+      this.bot.postMessageToThread(
         data.channel,
-        `Couldn't find that team! Teams list:\n${teamNames.join('\n')}`
+        `Couldn't find that team! Teams list:\n${teamNames.join('\n')}`,
+        data.ts
       );
       return;
     }


### PR DESCRIPTION
With lots of teams this ends up being a wall of text that most people other than the invoker don't care about